### PR TITLE
Fix allocated bytes assignment in PerfStart() method.

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -153,7 +153,7 @@ namespace TestRavenDB
 
             now = DateTime.UtcNow;
 
-            long alloc = GC.GetAllocatedBytesForCurrentThread();
+            alloc = GC.GetAllocatedBytesForCurrentThread();
         }
 
         public static void PerfStop(int count, int repeat)


### PR DESCRIPTION
Fix #1 - Update `PerfStart()` method to set allocated bytes for current thread to the static field.